### PR TITLE
Use inline css

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,9 +33,6 @@ export default {
     typescript(),
     svelte({
       dev: !production,
-      css: css => {
-        css.write('dist/index.css', production);
-      },
       preprocess: autoPreprocess(),
     }),
     resolve({


### PR DESCRIPTION
Separate CSS files do not get used when importing from npm directly (to test this, comment out the "svelte" key in package.json to force it to use the built files, as it would from npm).